### PR TITLE
Create desktop for fish shell in comment

### DIFF
--- a/.dotfiles/config/skhd/skhdrc
+++ b/.dotfiles/config/skhd/skhdrc
@@ -136,11 +136,20 @@ hyper - u : yabai -m window --toggle float;\
        index="$(yabai -m query --spaces --display | jq 'map(select(."native-fullscreen" == 0))[-1].index')" && \
        yabai -m window --space "${index}" && \
        yabai -m space --focus "${index}"  
+##### FISH SHELL SOLUTION
+# 0x53 : yabai -m space --create && \
+#        set index (yabai -m query --spaces --display | jq 'map(select(."native-fullscreen" == 0))[-1].index') && \
+#        yabai -m window --space $index && \
+#        yabai -m space --focus $index  
 
 # create desktop and follow focus - uses jq for parsing json (brew install jq)
 cmd - 0x53 : yabai -m space --create && \
        index="$(yabai -m query --spaces --display | jq 'map(select(."native-fullscreen" == 0))[-1].index')" && \
        yabai -m space --focus "${index}"  
+##### FISH SHELL SOLUTION
+# cmd - 0x53 : yabai -m space --create && \
+#        set index (yabai -m query --spaces --display | jq 'map(select(."native-fullscreen" == 0))[-1].index') && \
+#        yabai -m space --focus $index  
                    
 # destroy desktop
 cmd - 0x51 : yabai -m space --destroy


### PR DESCRIPTION
Bash-like command doesn't work because fish has command substitutions restriction (fish: Command substitutions not allowed).
Point working version in a comment.